### PR TITLE
Use Twitter API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,7 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+#Twitter credentials
+/scripts/auth.txt
+

--- a/README.md
+++ b/README.md
@@ -123,8 +123,22 @@ pprint.pprint(m3twitter.infer("test/twitter_cache/m3_input.jsonl")) #Same method
 If you already have images locally, please include the ``image_path_key`` parameter and set it to the key in your JSON object containing the path to the image locally. Similarly, if you have detected languages, you can use the ``lang_key`` parameter. An example is given in `test/test_transform_jsonl.py`
 
 ##### Nothing but a screen_name or numeric id
-You can also run the Twitter wrapper directly for a Twitter screen_name or numeric id. From the command line, this looks like:
+You can also run the Twitter wrapper directly for a Twitter screen_name or numeric id.
 
+* Please download the "scripts" folders from this repository. 
+* To run these examples, you need Twitter API credentials. Please create a Twitter app at https://developer.twitter.com/en/apps . Once you have an app, copy `auth_example.txt` to  `auth.txt` and insert the API key, API secret, access token, and access token secret into this file.
+
+Then you can run the following commands:
+
+```
+#If you have a screen_name, use
+$ python m3twitter.py --screen-name=computermacgyve --auth auth.txt --skip-cache
+
+#If you have a numeric id, use
+$python m3twitter.py --id=19854920 --auth auth.txt --skip-cache
+```
+
+The `--skip-cache` option ensures fresh results are retrieved rather than served from the cache. This is great for debugging but not in a real-world setting; so, remove as needed.
 
 ## FAQs
 ### What if I just have a Twitter screen name or id?
@@ -135,6 +149,7 @@ You can use the M3Twitter class to get all the needed profile information (and i
 import pprint
 from m3inference import M3Twitter
 m3twitter=M3Twitter()
+m3twitter.twitter_init(api_key=...,api_secret=...,access_token=...,access_secret=...)
 pprint.pprint(m3twitter.infer_id("2631881902"))
 ```
 
@@ -142,7 +157,7 @@ The `.infer_screen_name(...)`  method does the same for a Twitter screen name. A
 
 You can also run these examples directly from the terminal to try things out:
 ```
-python scripts/m3twitter.py --screen-name=barackobama
+python scripts/m3twitter.py --screen-name=barackobama --auth auth.txt
 ```
 
 ### How should I get the images?

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ If you already have images locally, please include the ``image_path_key`` parame
 You can also run the Twitter wrapper directly for a Twitter screen_name or numeric id.
 
 * Please download the "scripts" folders from this repository. 
-* To run these examples, you need Twitter API credentials. Please create a Twitter app at https://developer.twitter.com/en/apps . Once you have an app, copy `auth_example.txt` to  `auth.txt` and insert the API key, API secret, access token, and access token secret into this file.
+* To run these examples, you need Twitter API credentials. Please create a Twitter app at https://developer.twitter.com/en/apps . Once you have an app, copy `scripts/auth_example.txt` to  `auth.txt` and insert the API key, API secret, access token, and access token secret into this file.
 
 Then you can run the following commands:
 
@@ -149,7 +149,12 @@ You can use the M3Twitter class to get all the needed profile information (and i
 import pprint
 from m3inference import M3Twitter
 m3twitter=M3Twitter()
+
+# initialize twitter api
 m3twitter.twitter_init(api_key=...,api_secret=...,access_token=...,access_secret=...)
+# alternatively, you may do
+m3twitter.twitter_init_from_file('auth.txt')
+
 pprint.pprint(m3twitter.infer_id("2631881902"))
 ```
 

--- a/m3inference/m3inference.py
+++ b/m3inference/m3inference.py
@@ -46,7 +46,7 @@ class M3Inference:
         self.model_type = 'full_model' if self.use_full_model else 'text_model'
         self.model_dir = model_dir
 
-        logger.info('Version 1.0.3')
+        logger.info('Version 1.1.0')
         logger.info(f'Running on {self.device.type}.')
 
         if not pretrained:

--- a/m3inference/m3twitter.py
+++ b/m3inference/m3twitter.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # @Scott Hale
 
+import configparser
 import html
 import json
 import logging
@@ -139,7 +140,17 @@ class M3Twitter(M3Inference):
             json.dump(output, fh)
         return output
 
-    def twitter_init(self,api_key,api_secret,access_token,access_secret):
+    
+    def twitter_init_from_file(self, auth_file):
+        with open(auth_file, "r") as fh:
+            config_string = '[DEFAULT]\n' + fh.read()
+            config = configparser.ConfigParser()
+            config.read_string(config_string)
+            twcfg=dict(config.items("DEFAULT"))
+        return self.twitter_init(**twcfg)
+    
+    
+    def twitter_init(self, api_key, api_secret, access_token, access_secret):
         twitter = OAuth1Service(
             consumer_key=api_key,
             consumer_secret=api_secret,
@@ -160,14 +171,14 @@ class M3Twitter(M3Inference):
             try:
                 r=self.twitter_session.get("users/show.json",params={"screen_name":screen_name})
             except:
-                logger.warning("Invalid resonse from Twitter")
+                logger.warning("Invalid response from Twitter")
                 return None
         elif id!=None:
             logger.info("GET /users/show.json?id={}".format(id))
             try:
                 r=self.twitter_session.get("users/show.json",params={"id":id})
             except:
-                logger.warning("Invalid resonse from Twitter")
+                logger.warning("Invalid response from Twitter")
                 return None
         else:
             logger.fatal("No id or screen_name")

--- a/m3inference/m3twitter.py
+++ b/m3inference/m3twitter.py
@@ -5,8 +5,7 @@ import html
 import json
 import logging
 import os
-import re
-import urllib.request
+from rauth import OAuth1Service
 from os.path import expanduser
 
 from .consts import UNKNOWN_LANG, TW_DEFAULT_PROFILE_IMG
@@ -23,22 +22,18 @@ logger = logging.getLogger(__name__)
 def get_extension(img_path):
     dotpos = img_path.rfind(".")
     extension = img_path[dotpos + 1:]
-    if extension.lower() == "gif":
-        return "png"
+    #if extension.lower() == "gif":
+    #    return "png"
     return extension
 
 class M3Twitter(M3Inference):
-    _RE_IMG = re.compile('<img class="photo" src="https://pbs.twimg.com/profile_images/(.*?)".*?>(.*?)</a>', re.DOTALL)
-    _RE_BIO = re.compile('<p class="note">(.*?)</p>', re.DOTALL)
-    _TAG_RE = re.compile(r'<[^>]+>')
-    # _SCREEN_NAME=re.compile('<span class="nickname">@(.*?)</span>')
-    _NAME_SCREEN_NAME = re.compile(r'<title>(.*?) \(@(.*?)\)')
 
     def __init__(self, cache_dir=expanduser("~/m3/cache"), model_dir=expanduser("~/m3/models/"), pretrained=True,
                  use_full_model=True, use_cuda=True, parallel=False, seed=0):
         super(M3Twitter, self).__init__(model_dir=model_dir, pretrained=pretrained, use_full_model=use_full_model,
                                         use_cuda=use_cuda, parallel=parallel, seed=seed)
         self.cache_dir = cache_dir
+        self.twitter_session=None
         if not os.path.isdir(self.cache_dir):
             logger.info(f'Dir {self.cache_dir} does not exist. Creating now.')
             os.makedirs(self.cache_dir)
@@ -139,19 +134,47 @@ class M3Twitter(M3Inference):
         else:
             logger.info("skip_cache is True. Fetching data from Twitter for {}.".format(screen_name))
 
-        try:
-            data = urllib.request.urlopen("https://twitter.com/intent/user?screen_name={}".format(screen_name))
-            data = data.read().decode("UTF-8")
-        except urllib.error.HTTPError as err:
-            logger.warning(
-                "skip_cache is TrueError fetching data from Twitter. HTTP error code was {}. 404 usually indicates the screen_name is invalid.".format(
-                    err.code))
-            raise err
-
-        output = self.process_twitter(data, screen_name=screen_name)
+        output = self._twitter_api(screen_name=screen_name)
         with open("{}/{}.json".format(self.cache_dir, screen_name), "w") as fh:
             json.dump(output, fh)
         return output
+
+    def twitter_init(self,api_key,api_secret,access_token,access_secret):
+        twitter = OAuth1Service(
+            consumer_key=api_key,
+            consumer_secret=api_secret,
+            request_token_url='https://api.twitter.com/oauth/request_token',
+            access_token_url='https://api.twitter.com/oauth/access_token',
+            authorize_url='https://api.twitter.com/oauth/authorize',
+            base_url='https://api.twitter.com/1.1/')
+        self.twitter_session = twitter.get_session(token=[access_token,access_secret])
+        return True
+
+    def _twitter_api(self,id=None,screen_name=None):
+        if self.twitter_session==None:
+            logger.fatal("You must call twitter_init(...) before using this method. Please see https://github.com/euagendas/m3inference/blob/master/README.md for details.")
+            return None
+
+        if screen_name!=None:
+            logger.info("GET /users/show.json?screen_name={}".format(screen_name))
+            try:
+                r=self.twitter_session.get("users/show.json",params={"screen_name":screen_name})
+            except:
+                logger.warning("Invalid resonse from Twitter")
+                return None
+        elif id!=None:
+            logger.info("GET /users/show.json?id={}".format(id))
+            try:
+                r=self.twitter_session.get("users/show.json",params={"id":id})
+            except:
+                logger.warning("Invalid resonse from Twitter")
+                return None
+        else:
+            logger.fatal("No id or screen_name")
+            return None
+        
+        return self.process_twitter(r.json())
+
 
     def infer_id(self, id, skip_cache=False):
         """
@@ -171,69 +194,58 @@ class M3Twitter(M3Inference):
         else:
             logger.info("skip_cache is True. Fetching data from Twitter for id {}.".format(id))
 
-        try:
-            data = urllib.request.urlopen("https://twitter.com/intent/user?user_id={}".format(id))
-            data = data.read().decode("UTF-8")
-        except urllib.error.HTTPError as err:
-            logger.warning(
-                "Error fetching data from Twitter. HTTP error code was {}. 404 usually indicates the id is invalid.".format(
-                    err.code))
-            raise err
-
-        output = self.process_twitter(data, id=id)
+        output=self._twitter_api(id=id)
         with open("{}/{}.json".format(self.cache_dir, id), "w") as fh:
             json.dump(output, fh)
         return output
 
-    def process_twitter(self, data, screen_name=None, id=None):
-        img = M3Twitter._RE_IMG.findall(data)
-        bio = M3Twitter._RE_BIO.findall(data)
-        name_screen_name = M3Twitter._NAME_SCREEN_NAME.findall(data)
-
-        if len(name_screen_name) == 0:
-            logger.warning("Could not retreive the name or screen_name.")
-            name = ""
-            if screen_name == None:
-                screen_name = ""
+    def _get_twitter_attrib(self,key,data):
+        if key in data:
+            return data[key]
         else:
-            screen_name_parsed = name_screen_name[0][1].lower()
-            name = name_screen_name[0][0]
-            if screen_name == None:
-                screen_name = screen_name_parsed
-            elif screen_name_parsed != screen_name:
-                logger.info(
-                    "screen_name from Twitter does not match supplied screen_name. Using user-supplied screen_name. Twiter value is {}. User-supplied value is {}".format(
-                        screen_name_parsed, screen_name))
+            logger.warning("Could not retreive {}".format(key))
+            return ""
 
-        if len(img) == 0:
+    def process_twitter(self, data):
+        
+        screen_name=self._get_twitter_attrib("screen_name",data)
+        id=self._get_twitter_attrib("id_str",data)
+        bio=self._get_twitter_attrib("description",data)
+        name=self._get_twitter_attrib("name",data)
+        img=self._get_twitter_attrib("profile_image_url",data)
+        
+        if id=="":
+            id="dummy" #Can be anything since batch is of size 1
+
+        if bio == "":
+            lang = UNKNOWN_LANG
+        else:
+            lang = get_lang(bio)
+        
+        if img=="":
             logger.warning("Unable to extract image from Twitter. Using default image.")
             img_file_resize = TW_DEFAULT_PROFILE_IMG
         else:
-            img = "https://pbs.twimg.com/profile_images/{}".format(img[0][0])
             img = img.replace("_200x200", "_400x400")
+            img = img.replace("_normal", "_400x400")
             dotpos = img.rfind(".")
             img_file_full = "{}/{}.{}".format(self.cache_dir, screen_name, img[dotpos + 1:])
             img_file_resize = "{}/{}_224x224.{}".format(self.cache_dir, screen_name, get_extension(img))
             download_resize_img(img, img_file_resize, img_file_full)
-        if len(bio) == 0:
-            bio = ""
-            logger.warning("No bio available from Twitter")
-        else:
-            bio = html.unescape(M3Twitter._TAG_RE.sub('', bio[0]))
 
         data = [{
             "description": bio,
-            "id": id if id != None else screen_name,
+            "id": id,
             "img_path": img_file_resize,
-            "lang": get_lang(bio),
+            "lang": lang,
             "name": name,
-            "screen_name": screen_name
+            "screen_name": screen_name,
         }]
 
         pred = self.infer(data, batch_size=1, num_workers=1)
 
         output = {
             "input": data[0],
-            "output": pred[id if id != None else screen_name]
+            "output": pred[id]
         }
         return output

--- a/m3inference/m3twitter.py
+++ b/m3inference/m3twitter.py
@@ -22,8 +22,8 @@ logger = logging.getLogger(__name__)
 def get_extension(img_path):
     dotpos = img_path.rfind(".")
     extension = img_path[dotpos + 1:]
-    #if extension.lower() == "gif":
-    #    return "png"
+    if extension.lower() == "gif":
+        return "png"
     return extension
 
 class M3Twitter(M3Inference):

--- a/m3inference/preprocess.py
+++ b/m3inference/preprocess.py
@@ -29,21 +29,21 @@ def download_resize_img(url, img_out_path, img_out_path_fullsize=None):
                 fh.write(img_data)
     except urllib.error.HTTPError as err:
         logger.warn("Error fetching profile image from Twitter. HTTP error code was {}.".format(err.code))
-        raise err
+        return None
 
-    return resize_img(BytesIO(img_data), img_out_path, force=True)
+    return resize_img(BytesIO(img_data), img_out_path, force=True,url=url)
 
 
-def resize_img(img_path, img_out_path, filter=Image.BILINEAR, force=False):
+def resize_img(img_path, img_out_path, filter=Image.BILINEAR, force=False,url=None):
     try:
         img = Image.open(img_path).convert("RGB")
         if img.size[0] + img.size[1] < 400 and not force:
-            logger.info(f'{img_path} is too small. Skip.')
+            logger.info(f'{img_path} / {url} is too small. Skip.')
             return
         img = img.resize((224, 224), filter)
         img.save(img_out_path)
     except Exception as e:
-        logger.warning(f'Error when resizing {img_path}\nThe error message is {e}\n')
+        logger.warning(f'Error when resizing {img_path} / {url}\nThe error message is {e}\n')
 
 
 def resize_imgs(src_root, dest_root, src_list=None, filter=Image.BILINEAR, force=False):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ torchvision>=0.2.2
 pycld2>=0.31
 requests
 pandas>=0.20
+rauth

--- a/scripts/auth_example.txt
+++ b/scripts/auth_example.txt
@@ -1,0 +1,4 @@
+api_key:
+api_secret:
+access_token:
+access_secret:

--- a/scripts/m3twitter.py
+++ b/scripts/m3twitter.py
@@ -27,12 +27,7 @@ if __name__ == "__main__":
 
     m3Twitter = M3Twitter()
     
-    with open(args.auth, "r") as fh:
-        config_string = '[DEFAULT]\n' + fh.read()
-        config = configparser.ConfigParser()
-        config.read_string(config_string)
-        twcfg=dict(config.items("DEFAULT"))
-        m3Twitter.twitter_init(**twcfg)
+    m3Twitter.twitter_init_from_file(args.auth)
 
     if args.id != None:
         pprint.pprint(m3Twitter.infer_id(args.id, skip_cache=args.skip_cache))

--- a/scripts/m3twitter.py
+++ b/scripts/m3twitter.py
@@ -5,10 +5,12 @@ from m3inference import M3Twitter
 import pprint
 import argparse
 import sys
+import configparser
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description='Retreive profile information for a Twitter screen_name or numeric user id and run m3 inference. You must supply exactly ONE of --id or --screen-name')
+    parser.add_argument('--auth', help='A file with Twitter API credentials (see README)', required=True)
     parser.add_argument('--id', help='The numeric id of a Twitter user')
     parser.add_argument('--screen-name',
                         help='The screen_name of a Twitter user (i.e., everything following the @, but do not include @ itself)')
@@ -24,6 +26,14 @@ if __name__ == "__main__":
         quit(1)
 
     m3Twitter = M3Twitter()
+    
+    with open(args.auth, "r") as fh:
+        config_string = '[DEFAULT]\n' + fh.read()
+        config = configparser.ConfigParser()
+        config.read_string(config_string)
+        twcfg=dict(config.items("DEFAULT"))
+        m3Twitter.twitter_init(**twcfg)
+
     if args.id != None:
         pprint.pprint(m3Twitter.infer_id(args.id, skip_cache=args.skip_cache))
     else:

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('requirements.txt') as f:
 
 setuptools.setup(
     name='m3inference',
-    version='1.0.3',
+    version='1.1.0',
     author='Zijian Wang et al.',
     author_email='zijwang@stanford.edu',
     description='M3 Inference',


### PR DESCRIPTION
We previously just parsed the HTML of profile pages to get the needed information when given a Twitter username or id. That method is no longer working (Twitter doesn't serve the needed information).

This PR now uses the Twitter API. This is annoying in that anyone using the library in this way will need to create a Twitter app, abut it is not going to break (as easily) in the future.

I've tested but would value a second pair of eyes.