### PR TITLE
Add support for win 64-bit

### DIFF
--- a/scripts/m3twitter.py
+++ b/scripts/m3twitter.py
@@ -6,8 +6,10 @@ import pprint
 import argparse
 import sys
 import configparser
+from multiprocessing import freeze_support
 
 if __name__ == "__main__":
+    freeze_support()
     parser = argparse.ArgumentParser(
         description='Retreive profile information for a Twitter screen_name or numeric user id and run m3 inference. You must supply exactly ONE of --id or --screen-name')
     parser.add_argument('--auth', help='A file with Twitter API credentials (see README)', required=True)

--- a/scripts/preprocess.py
+++ b/scripts/preprocess.py
@@ -4,11 +4,12 @@
 import argparse
 import logging
 from m3inference.preprocess import resize_imgs, update_json
-
+from multiprocessing import freeze_support
 
 logger = logging.getLogger()
 
 if __name__ == "__main__":
+    freeze_support()
     parser = argparse.ArgumentParser()
     parser.add_argument('--source_dir', type=str, default=None, required=True,
                         help='The source dir that contains images that need to be resized')


### PR DESCRIPTION
Per  #10 , the multiprocessing in pytorch requires that 
What you'll see in that file is that 
1. I make sure the contents of my main program are within a
```
if __name__ == "__main__":
````
block
2. The first statement of that block is `freeze_support()`
3. I have imported that freeze_support function from multiprocessing, i.e.,
``` 
from multiprocessing import freeze_support
```

I've adapted `scripts/m3twitter.py` and `scripts/preprocess.py` to follow this convention.

I have confirmed these changes have no effect on linux, but do not have access to a 64-bit windows machine to test. 
(I have an old virtual box with a 32-bit install of windows but pytorch is not available for 32-bit systems)