### PR TITLE
add support to disable all logs and tqdm bars

### DIFF
--- a/m3inference/m3twitter.py
+++ b/m3inference/m3twitter.py
@@ -32,9 +32,9 @@ def get_extension(img_path):
 class M3Twitter(M3Inference):
 
     def __init__(self, cache_dir=expanduser("~/m3/cache"), model_dir=expanduser("~/m3/models/"), pretrained=True,
-                 use_full_model=True, use_cuda=True, parallel=False, seed=0):
+                 use_full_model=True, use_cuda=True, parallel=False, seed=0, skip_logging=False):
         super(M3Twitter, self).__init__(model_dir=model_dir, pretrained=pretrained, use_full_model=use_full_model,
-                                        use_cuda=use_cuda, parallel=parallel, seed=seed)
+                                        use_cuda=use_cuda, parallel=parallel, seed=seed, skip_logging=skip_logging)
         self.cache_dir = cache_dir
         self.twitter_session=None
         if not os.path.isdir(self.cache_dir):

--- a/m3inference/preprocess.py
+++ b/m3inference/preprocess.py
@@ -58,7 +58,7 @@ def resize_imgs(src_root, dest_root, src_list=None, filter=Image.BILINEAR, force
     des_set = set([os.path.relpath(img_path, dest_root).replace('.jpeg', '')
                    for img_path in glob.glob(os.path.join(dest_root, '*'))])
 
-    for img_path in tqdm(src_list, desc='resizing images'):
+    for img_path in tqdm(src_list, desc='resizing images', disable=logging.root.level>=logging.WARN):
 
         img_name = os.path.splitext(os.path.relpath(img_path, src_root))[0]
         if not force and img_name in des_set:

--- a/m3inference/utils.py
+++ b/m3inference/utils.py
@@ -82,7 +82,7 @@ def fetch_pretrained_model(model_name, model_path):
             req = requests.get(model_url, stream=True)
             content_length = req.headers.get('Content-Length')
             total = int(content_length) if content_length is not None else None
-            progress = tqdm(unit="KB", total=round(total / 1024))
+            progress = tqdm(unit="KB", total=round(total / 1024), disable=logging.root.level>=logging.WARN)
             for chunk in req.iter_content(chunk_size=1024):
                 if chunk:  # filter out keep-alive new chunks
                     progress.update(1)

--- a/scripts/m3twitter.py
+++ b/scripts/m3twitter.py
@@ -6,10 +6,11 @@ import pprint
 import argparse
 import sys
 import configparser
+import logging
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        description='Retreive profile information for a Twitter screen_name or numeric user id and run m3 inference. You must supply exactly ONE of --id or --screen-name')
+        description='Retrieve profile information for a Twitter screen_name or numeric user id and run m3 inference. You must supply exactly ONE of --id or --screen-name')
     parser.add_argument('--auth', help='A file with Twitter API credentials (see README)', required=True)
     parser.add_argument('--id', help='The numeric id of a Twitter user')
     parser.add_argument('--screen-name',
@@ -17,6 +18,8 @@ if __name__ == "__main__":
     # parser.add_argument('--skip-cache', type=bool, nargs='?',const=True, default=False,help='By default all requests are cached to the local filesystem and not refetched. Include this flag to disable/overwrite any results already in the cache.')
     parser.add_argument('--skip-cache', dest='skip_cache', action='store_true',
                         help='By default all requests are cached to the local filesystem and not refetched. Include this flag to disable/overwrite any results already in the cache.')
+    parser.add_argument('--skip_logging', action='store_true', required=False, help='(Optional) Skip logging info if set.')
+
     parser.set_defaults(skip_cache=False)
     args = parser.parse_args()
     if (args.id == None) == (args.screen_name == None):
@@ -25,7 +28,7 @@ if __name__ == "__main__":
         parser.print_help(sys.stderr)
         quit(1)
 
-    m3Twitter = M3Twitter()
+    m3Twitter = M3Twitter(skip_logging=args.skip_logging)
     
     m3Twitter.twitter_init_from_file(args.auth)
 

--- a/scripts/preprocess.py
+++ b/scripts/preprocess.py
@@ -22,13 +22,19 @@ if __name__ == "__main__":
                         help='(Optional) The path to write the updated jsonl file (must be used with `--json_filepath')
 
     parser.add_argument('--force', action='store_true', required=False,
-                        help='(Optional) Force resieing every image, even if it exists in the output_dir.')
+                        help='(Optional) Force resizing every image, even if it exists in the output_dir.')
 
-    parser.add_argument('--verbose', action='store_true', required=False, help='(Optional) Verbose mode')
+    parser.add_argument('--verbose', action='store_true', required=False, help='(Optional) Print debug message if set')
+
+    parser.add_argument('--skip_logging', action='store_true', required=False, help='(Optional) Skip logging info if set. Overwrite `verbose`.')
 
     args = parser.parse_args()
+
     if args.verbose:
         logger.setLevel(logging.DEBUG)
+
+    if args.skip_logging:
+        logging.getLogger().setLevel(logging.WARN)
 
     resize_imgs(args.source_dir, args.output_dir, force=args.force)
     if args.jsonl_path:

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('requirements.txt') as f:
 
 setuptools.setup(
     name='m3inference',
-    version='1.1.3',
+    version='1.1.4',
     author='Zijian Wang et al.',
     author_email='zijwang@stanford.edu',
     description='M3 Inference',


### PR DESCRIPTION
based on https://github.com/euagendas/m3inference/pull/17

Test:

```
> python scripts/preprocess.py --source_dir test/pic/ --output_dir test/pic_resized/ --jsonl_path test/data.jsonl --jsonl_outpath test/data_resized.jsonl --skip_logging
(no output)
```

```
>>> from m3inference import M3Inference
>>> import pprint
>>> m3 = M3Inference(skip_logging=True)
>>> pred = m3.infer('./test/data_resized.jsonl') # also see docstring for details
>>> pprint.pprint(pred)
OrderedDict([('720389270335135745',
              {'age': {'19-29': 0.1546,
                       '30-39': 0.114,
                       '<=18': 0.0481,
                       '>=40': 0.6833},
...
```