### PR TITLE
fix urllib errors while trying to fetch a profile image from twitter

### DIFF
--- a/m3inference/m3twitter.py
+++ b/m3inference/m3twitter.py
@@ -93,6 +93,10 @@ class M3Twitter(M3Inference):
                     download_resize_img(img_path, img_file_resize, img_file_full)
                 else:
                     download_resize_img(img_path, img_file_resize)
+        # check if an error occurred and the image was not downloaded
+        if not os.path.exists(img_file_resize):
+            img_file_resize = TW_DEFAULT_PROFILE_IMG
+
         bio = user["description"]
         if bio == None:
             bio = ""

--- a/m3inference/preprocess.py
+++ b/m3inference/preprocess.py
@@ -6,7 +6,7 @@ import glob
 import json
 import logging
 import os
-import urllib.request
+import urllib.request, urllib.error
 from io import BytesIO
 
 from PIL import Image
@@ -29,6 +29,15 @@ def download_resize_img(url, img_out_path, img_out_path_fullsize=None):
                 fh.write(img_data)
     except urllib.error.HTTPError as err:
         logger.warn("Error fetching profile image from Twitter. HTTP error code was {}.".format(err.code))
+        return None
+    except urllib.error.ContentTooShortError:
+        logger.warn("Error fetching profile image from Twitter. The amount of data downloaded is less than the expected amount")
+        return None
+    except (urllib.error.URLError, ValueError) as err:
+        logger.warn("Error fetching profile image from Twitter. {}".format(err))
+        return None
+    except:
+        logger.warn("Unknown Error")
         return None
 
     return resize_img(BytesIO(img_data), img_out_path, force=True,url=url)


### PR DESCRIPTION
Added more exceptions in preprocess.py to handle `urllib` remaining errors like `ContentTooShortError`, which occurred while I was fetching profile images from Twitter.

The same goes for `ValueError`, which I have encountered when the field `profile_image_url_https` in the twitter json was empty (i.e. "")

At last, I have added a line in m3twitter.py to verify if the profile image was successfully downloaded: if that's not the case, `TW_DEFAULT_PROFILE_IMG` is used to avoid crash during the infer phase.