### PR TITLE
ASCIIfy screen_name in dataset.py

### DIFF
--- a/m3inference/dataset.py
+++ b/m3inference/dataset.py
@@ -23,11 +23,11 @@ class M3InferenceDataset(Dataset):
             entry = DotDict(entry)
             if use_img:
                 self.data.append([entry.id, entry.lang, normalize_space(str(entry.name)),
-                                  normalize_space(str(entry.screen_name)),
+                                  ascii(normalize_space(str(entry.screen_name))),
                                   normalize_url(normalize_space(str(entry.description))), entry.img_path])
             else:
                 self.data.append([entry.id, entry.lang, normalize_space(str(entry.name)),
-                                  normalize_space(str(entry.screen_name)),
+                                  ascii(normalize_space(str(entry.screen_name))),
                                   normalize_url(normalize_space(str(entry.description)))])
 
         logger.info(f'{len(self.data)} data entries loaded.')


### PR DESCRIPTION
We need to asciify the screen_name since it can contain non-ASCII characters and the screenname_embed input size (EMBEDDING_INPUT_SIZE_ASCII in consts.py) is 128 (which covers the lower half of ASCII characters)

An example is below. Notice that screen_name starts with an 'ı' which is a non-ASCII Turkish character.
{"description": "ileri", "id": "1", "lang": "tr", "name": "ılyas", "screen_name": "ılyas02805430"}